### PR TITLE
Add symlink to normalize "npm start" and "npm run demo"

### DIFF
--- a/generators/project/templates/config/_gitignore
+++ b/generators/project/templates/config/_gitignore
@@ -13,5 +13,8 @@ app/templates.js
 app/style.css
 app/style.css.map
 
+# Symlink to normalize "npm start" and "npm run demo"
+app/assets
+
 # SASS projects
 .sass-cache/

--- a/generators/webapp/index.js
+++ b/generators/webapp/index.js
@@ -234,12 +234,14 @@ module.exports = Generator.extend({
         utils.json.extend(generator.destinationPath('package.json'), {
             main: sourceDirectory + 'app/main.js',
             scripts: {
-                build:     'grunt build',
-                test:      'grunt test',
-                predemo:   'npm run build',
-                demo:      'grunt open:demo express:demo',
-                start:     'grunt serve',
-                predeploy: 'npm run build'
+                presymlink: 'if [ -L `pwd`/app/assets ]; then rm `pwd`/app/assets ; fi',
+                symlink:    'ln -s `pwd`/assets `pwd`/app/assets',
+                build:      'grunt build',
+                test:       'grunt test',
+                predemo:    'npm run build',
+                demo:       'grunt open:demo express:demo',
+                start:      'npm run symlink && grunt serve',
+                predeploy:  'npm run build'
             }
         });
         if (/^linux/.test(process.platform)) {


### PR DESCRIPTION
"Development" and "production" code have did folder structures ("production" is "flatter")

This PR adds an npm script, `npm run symlink`, that runs inside the `prestart` script.