### PR TITLE
Babel build integration

### DIFF
--- a/generators/app/gruntTaskConfigs.js
+++ b/generators/app/gruntTaskConfigs.js
@@ -330,6 +330,7 @@ module.exports = {
                         .replace(/[.]hbs/, "");
                 },
                 templateSettings: {
+                    variable: 'data',
                     interpolate : /\{\{(.+?)\}\}/g
                 }
             },

--- a/generators/app/gruntTaskConfigs.js
+++ b/generators/app/gruntTaskConfigs.js
@@ -488,23 +488,13 @@ module.exports = {
     requirejs: `{
         bundle: {
             options: {
-                out: '<%= folders.dist %>/<%= folders.client %>/<%= files.configScript %>',
+                out: '<%= folders.dist %>/<%= folders.client %>/temp.js',
                 mainConfigFile: '<%= folders.app %>/<%= files.configScript %>',
                 baseUrl: '<%= folders.app %>',
                 include: ['<%= files.configScript %>'],
                 preserveLicenseComments: false,
                 findNestedDependencies: true,
-                optimize: 'uglify2',
-                uglify2: {
-                    output: {
-                        comments: false,
-                        preamble: '/* <%= package.name %> - v<%= package.version %> - ' +
-                                  '2016-02-07 */'
-                    },
-                    compress: {
-                        drop_console: true //discard calls to console.* functions
-                    }
-                }
+                optimize: 'none'
             }
         }
     }`,

--- a/generators/project/templates/config/_eslintrc_webapp.js
+++ b/generators/project/templates/config/_eslintrc_webapp.js
@@ -1,9 +1,10 @@
 module.exports = {
     env: {
         amd: true,
+        es6: true,
         browser: true,
         jquery: true,
-        mocha: true
+        mocha: true,
     },
     globals: {
         sinon: true

--- a/generators/webapp/index.js
+++ b/generators/webapp/index.js
@@ -252,7 +252,6 @@ module.exports = Generator.extend({
             let workflowDependencies = [
                 'babel-cli',
                 'babel-preset-env',
-                'babel-plugin-transform-with',
                 'config',
                 'eslint-plugin-backbone',
                 'fs-promise',
@@ -318,7 +317,7 @@ module.exports = Generator.extend({
                 test:         'grunt test',
                 'test:watch': 'grunt karma:covering'
             };
-            let plugins = ['transform-with'];// babel plugins
+            let plugins = [];// babel plugins
             let presets = [['env', {modules: false}]];// babel presets
             if (isNative) {
                 main = './index.js';

--- a/generators/webapp/index.js
+++ b/generators/webapp/index.js
@@ -215,6 +215,7 @@ module.exports = Generator.extend({
                 'browserify',
                 'browserify-shim',
                 'aliasify',
+                'babelify',
                 'deamdify',
                 'grunt-browserify',
                 'grunt-replace'
@@ -249,13 +250,19 @@ module.exports = Generator.extend({
                 'karma-spec-reporter'
             ];
             let workflowDependencies = [
+                'babel-cli',
+                'babel-preset-env',
                 'config',
                 'eslint-plugin-backbone',
                 'fs-promise',
                 'globby',
                 'json-server',
                 'phantomjs-prebuilt'
-            ].concat(
+            ]
+            .concat(// conditional dependencies
+                !useBrowserify ? 'babel-preset-babili' : []
+            )
+            .concat(
                 gruntDependencies,
                 karmaDependencies,
                 requirejsDevDependencies,
@@ -310,6 +317,7 @@ module.exports = Generator.extend({
                 test:         'grunt test',
                 'test:watch': 'grunt karma:covering'
             };
+            let presets = [['env', {modules: false}]];// babel presets
             if (isNative) {
                 main = './index.js';
                 assign(scripts, {
@@ -343,7 +351,7 @@ module.exports = Generator.extend({
                         lodash:     './node_modules/lodash/lodash.min.js'
                     },
                     browserify: {
-                        transform: ['deamdify', 'browserify-shim', 'aliasify']
+                        transform: ['deamdify', 'browserify-shim', 'aliasify', 'babelify']
                     },
                     'browserify-shim': {
                         underscore: '_'
@@ -362,8 +370,17 @@ module.exports = Generator.extend({
                         }
                     }
                 });
+            } else {
+                // CAUTION: This is a static reference to dist/client directory
+                let dist = './dist/client/';
+                let temp = `${dist}temp.js`;
+                assign(scripts, {
+                    postbuild: `babel ${temp} -o ${dist}config.js && rm ${temp}`
+                });
+                presets = presets.concat('babili');
             }
-            updatePackageJson({main, scripts});
+            let babel = {babel: {presets}};
+            updatePackageJson({main, scripts, babel});
         },
         configureWorkflowTasks: function() {
             const placeholder = '/* -- load tasks placeholder -- */';

--- a/generators/webapp/index.js
+++ b/generators/webapp/index.js
@@ -252,6 +252,7 @@ module.exports = Generator.extend({
             let workflowDependencies = [
                 'babel-cli',
                 'babel-preset-env',
+                'babel-plugin-transform-with',
                 'config',
                 'eslint-plugin-backbone',
                 'fs-promise',
@@ -317,6 +318,7 @@ module.exports = Generator.extend({
                 test:         'grunt test',
                 'test:watch': 'grunt karma:covering'
             };
+            let plugins = ['transform-with'];// babel plugins
             let presets = [['env', {modules: false}]];// babel presets
             if (isNative) {
                 main = './index.js';
@@ -379,7 +381,7 @@ module.exports = Generator.extend({
                 });
                 presets = presets.concat('babili');
             }
-            let babel = {babel: {presets}};
+            let babel = {plugins, presets};
             updatePackageJson({main, scripts, babel});
         },
         configureWorkflowTasks: function() {

--- a/generators/webapp/templates/example.template.hbs
+++ b/generators/webapp/templates/example.template.hbs
@@ -2,5 +2,5 @@
 <nav role="navigation"></nav>
 <section id="main"></section>
 <footer role="contentinfo">
-    <a href="#">{{ name }}</a> was made with <span style="color: red;font-weight: bold;">❤</span> using <a href="https://github.com/omahajs/generator-omaha">OMAHA JS</a>
+    <a href="#">{{ <% if (!useHandlebars) { %>data.<% } %>name }}</a> was made with <span style="color: red;font-weight: bold;">❤</span> using <a href="https://github.com/omahajs/generator-omaha">OMAHA JS</a>
 </footer>

--- a/test/default.js
+++ b/test/default.js
@@ -71,7 +71,7 @@ describe('Default generator', function() {
                     verifyBoilerplateFiles('./');
                     verifyDefaultConfiguration();
                     verifyDefaultTasksConfiguration();
-                    assert.noFileContent('config/.eslintrc.js', 'es6: true,');
+                    assert.fileContent('config/.eslintrc.js', 'es6: true,');
                     assert.fileContent('config/.eslintrc.js', 'backbone/defaults-on-top');
                 });
         });


### PR DESCRIPTION
- Add babel to build pipeline to allow legacy support while using ES6 syntax.
> **Note:** Babel integration will not be added to testing workflow. The karma launcher, `ChromeHeadless` ,will be used for headless running that will allow for ES6 syntax in application source