### PR TITLE
Boilerplate and code refinements

### DIFF
--- a/generators/project/index.js
+++ b/generators/project/index.js
@@ -11,10 +11,9 @@ const { project } = require('../app/prompts');
 const tasks = require('../app/gruntTaskConfigs');
 const {
     copyTpl,
+    maybeInclude: iff,
     json: { extend }
 } = require('../app/utils');
-
-const iff = (condition, data, defaultValue = []) => condition ? data : defaultValue;
 
 const COMMAND_LINE_OPTIONS = {
     defaults: {

--- a/generators/webapp/index.js
+++ b/generators/webapp/index.js
@@ -10,8 +10,8 @@ const tasks = require('../app/gruntTaskConfigs');
 const {
     copy,
     copyTpl,
-    maybeInclude,
     parseModuleData,
+    maybeInclude: iff,
     json: { extend }
 } = require('../app/utils');
 
@@ -162,19 +162,19 @@ module.exports = class extends Generator {
         config.set('pluginDirectory', sourceDirectory);
         [// always included
         ['config/stylelint.config.js', 'config/stylelint.config.js'], ['tasks/webapp.js', 'tasks/webapp.js']].concat( // optional dependencies
-        maybeInclude(useAmd, [['_config.js', `${appDirectory}config.js`]])).concat( // conditional dependencies
-        maybeInclude(useAmd, [['test/config.js', 'test/config.js'], ['config/_karma.conf.amd.js', 'config/karma.conf.js']])).concat(maybeInclude(!(useAmd || useJest || useWebpack), [['config/_karma.conf.cjs.js', 'config/karma.conf.js']])).forEach(data => copyTpl(...data, generator));
+        iff(useAmd, [['_config.js', `${appDirectory}config.js`]])).concat( // conditional dependencies
+        iff(useAmd, [['test/config.js', 'test/config.js'], ['config/_karma.conf.amd.js', 'config/karma.conf.js']])).concat(iff(!(useAmd || useJest || useWebpack), [['config/_karma.conf.cjs.js', 'config/karma.conf.js']])).forEach(data => copyTpl(...data, generator));
         //
         // Write boilerplate files
         //
-        [].concat(maybeInclude(useHandlebars, [['helpers/handlebars.helpers.js', 'helpers/handlebars.helpers.js']]), maybeInclude(useAmd, [['example.webworker.js', 'controllers/example.webworker.js']]), [['helpers/jquery.extensions.js', 'helpers/jquery.extensions.js']], [['plugins/*.js', 'plugins']], [['shims/*.js', 'shims']], [['_index.html', 'index.html']], [['_app.js', 'app.js']], [['_main.js', 'main.js']], [['_router.js', 'router.js']], [['example.model.js', 'models/example.js']], [['example.view.js', 'views/example.js']], [['example.controller.js', 'controllers/example.js']]).map(data => [data[0], `${appDirectory}${data[1]}`]).forEach(data => copyTpl(...data, generator));
+        [].concat(iff(useHandlebars, [['helpers/handlebars.helpers.js', 'helpers/handlebars.helpers.js']]), iff(useAmd, [['example.webworker.js', 'controllers/example.webworker.js']]), [['helpers/jquery.extensions.js', 'helpers/jquery.extensions.js']], [['plugins/*.js', 'plugins']], [['shims/*.js', 'shims']], [['_index.html', 'index.html']], [['_app.js', 'app.js']], [['_main.js', 'main.js']], [['_router.js', 'router.js']], [['example.model.js', 'models/example.js']], [['example.view.js', 'views/example.js']], [['example.controller.js', 'controllers/example.js']]).map(data => [data[0], `${appDirectory}${data[1]}`]).forEach(data => copyTpl(...data, generator));
         //
         // Write assets files
         //
         ['fonts', 'images', 'templates', 'library'].forEach(path => mkdirp(`${assetsDirectory}${path}`));
         copy('library/*', `${assetsDirectory}library`, generator);
         copy('omaha.png', `${assetsDirectory}images/logo.png`, generator);
-        [].concat(maybeInclude(type === 'none', [[// No CSS pre-processor
+        [].concat(iff(type === 'none', [[// No CSS pre-processor
         '_style.css', 'css/style.css']], [[// Main style sheet
         `_style.${ext}`, `${type}/style.${ext}`]]), [['example.template.hbs', 'templates/example.hbs']]).map(data => [data[0], `${assetsDirectory}${data[1]}`]).forEach(data => copyTpl(...data, generator));
     }
@@ -190,15 +190,15 @@ module.exports = class extends Generator {
         const loadTasks = 'grunt.loadTasks(config.folders.tasks);';
         const dependencies = [// always included
         'backbone', 'backbone.marionette', 'backbone.radio', 'jquery', 'lodash', 'morphdom', 'redux'].concat( // conditional dependencies
-        maybeInclude(useHandlebars, 'handlebars'), maybeInclude(useAmd, 'requirejs'));
+        iff(useHandlebars, 'handlebars'), iff(useAmd, 'requirejs'));
         const htmlDevDependencies = ['grunt-contrib-htmlmin', 'grunt-htmlhint-plus'];
-        const cssDevDependencies = ['grunt-postcss', 'autoprefixer', 'stylelint', 'cssnano', 'normalize.css', 'postcss-reporter', 'postcss-safe-parser', 'mdcss', 'mdcss-theme-github'].concat(maybeInclude(type === 'none', ['postcss-import', 'postcss-cssnext']));
+        const cssDevDependencies = ['grunt-postcss', 'autoprefixer', 'stylelint', 'cssnano', 'normalize.css', 'postcss-reporter', 'postcss-safe-parser', 'mdcss', 'mdcss-theme-github'].concat(iff(type === 'none', ['postcss-import', 'postcss-cssnext']));
         const requirejsDevDependencies = ['grunt-contrib-requirejs', 'karma-requirejs'];
-        const browserifyDependencies = ['browserify', 'browserify-shim', 'aliasify', 'babelify', 'deamdify', 'grunt-browserify'].concat(maybeInclude(useBrowserify && !useJest, ['karma-browserify', 'browserify-istanbul']));
-        const gruntDependencies = ['grunt', 'grunt-browser-sync', 'grunt-cli', 'grunt-contrib-clean', 'grunt-contrib-copy', 'grunt-contrib-uglify', 'grunt-contrib-watch', 'grunt-eslint', 'grunt-express', 'grunt-jsdoc', 'grunt-jsonlint', 'grunt-open', 'grunt-parallel', 'grunt-plato', 'grunt-replace', 'load-grunt-tasks', 'time-grunt'].concat(maybeInclude(!useJest, 'grunt-karma'));
+        const browserifyDependencies = ['browserify', 'browserify-shim', 'aliasify', 'babelify', 'deamdify', 'grunt-browserify'].concat(iff(useBrowserify && !useJest, ['karma-browserify', 'browserify-istanbul']));
+        const gruntDependencies = ['grunt', 'grunt-browser-sync', 'grunt-cli', 'grunt-contrib-clean', 'grunt-contrib-copy', 'grunt-contrib-uglify', 'grunt-contrib-watch', 'grunt-eslint', 'grunt-express', 'grunt-jsdoc', 'grunt-jsonlint', 'grunt-open', 'grunt-parallel', 'grunt-plato', 'grunt-replace', 'load-grunt-tasks', 'time-grunt'].concat(iff(!useJest, 'grunt-karma'));
         const workflowDependencies = ['babel-cli', 'babel-preset-env', 'config', 'eslint-plugin-backbone', 'fs-promise', 'globby', 'json-server'].concat( // conditional dependencies
-        maybeInclude(!useBrowserify, 'babel-preset-minify'), maybeInclude(!useJest, requirejsDevDependencies), ...gruntDependencies, ...htmlDevDependencies, ...cssDevDependencies);
-        const devDependencies = workflowDependencies.concat(maybeInclude(useBrowserify, browserifyDependencies), maybeInclude(useAria, ['grunt-a11y', 'grunt-accessibility']), maybeInclude(useImagemin, 'grunt-contrib-imagemin'), maybeInclude(useLess, 'grunt-contrib-less'), maybeInclude(useSass, 'grunt-contrib-sass'), maybeInclude(useHandlebars, 'grunt-contrib-handlebars', 'grunt-contrib-jst'));
+        iff(!useBrowserify, 'babel-preset-minify'), iff(!useJest, requirejsDevDependencies), ...gruntDependencies, ...htmlDevDependencies, ...cssDevDependencies);
+        const devDependencies = workflowDependencies.concat(iff(useBrowserify, browserifyDependencies), iff(useAria, ['grunt-a11y', 'grunt-accessibility']), iff(useImagemin, 'grunt-contrib-imagemin'), iff(useLess, 'grunt-contrib-less'), iff(useSass, 'grunt-contrib-sass'), iff(useHandlebars, 'grunt-contrib-handlebars', 'grunt-contrib-jst'));
         generator.npmInstall(dependencies, { save: true });
         generator.npmInstall(devDependencies, { saveDev: true });
         //
@@ -286,7 +286,7 @@ function getPackageJsonAttributes() {
     const scripts = getScripts(generator);
     const babel = {
         plugins: [],
-        presets: [['env', { modules: false }]].concat(maybeInclude(!useBrowserify, 'minify'))
+        presets: [['env', { modules: false }]].concat(iff(!useBrowserify, 'minify'))
     };
     const stylelint = { extends: './config/stylelint.config.js' };
     return { main, scripts, babel, stylelint };
@@ -348,6 +348,6 @@ function getTasks(generator) {
     const { useBenchmark, useCoveralls, useJsinspect, useWebpack } = config.getAll();
     return [// Tasks enabled by default
     'browserSync', 'clean', 'copy', 'eslint', 'htmlmin', 'htmlhintplus', 'jsdoc', 'jsonlint', 'karma', 'open', 'plato', 'replace', 'requirejs', 'watch'].concat( // Project tasks enabled by user
-    maybeInclude(useBenchmark, 'benchmark'), maybeInclude(useCoveralls, 'coveralls'), maybeInclude(useJsinspect, 'jsinspect')).concat( // Webapp tasks enabled by user
-    maybeInclude(useAria, ['a11y', 'accessibility']), maybeInclude(useBrowserify, 'browserify'), maybeInclude(useHandlebars, 'handlebars', 'jst'), maybeInclude(useImagemin, ['imagemin', 'copy']), maybeInclude(useLess, 'less'), maybeInclude(useSass, 'sass'), maybeInclude(useWebpack, 'webpack'), maybeInclude(useWebpack || useBrowserify, 'uglify'));
+    iff(useBenchmark, 'benchmark'), iff(useCoveralls, 'coveralls'), iff(useJsinspect, 'jsinspect')).concat( // Webapp tasks enabled by user
+    iff(useAria, ['a11y', 'accessibility']), iff(useBrowserify, 'browserify'), iff(useHandlebars, 'handlebars', 'jst'), iff(useImagemin, ['imagemin', 'copy']), iff(useLess, 'less'), iff(useSass, 'sass'), iff(useWebpack, 'webpack'), iff(useWebpack || useBrowserify, 'uglify'));
 }

--- a/generators/webapp/templates/_app.js
+++ b/generators/webapp/templates/_app.js
@@ -6,8 +6,7 @@
  * @module app
  * @exports app
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports, module) {
-<% } %>
+define(function(require, exports, module) {<% } %>
     'use strict';
 
     const Mn      = require('backbone.marionette');

--- a/generators/webapp/templates/_main.js
+++ b/generators/webapp/templates/_main.js
@@ -5,8 +5,7 @@
  * @requires router
  * @requires views/example
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     const Backbone = require('backbone');

--- a/generators/webapp/templates/_router.js
+++ b/generators/webapp/templates/_router.js
@@ -3,8 +3,7 @@
  * @author <%= userName %>
  * @module router
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports) {
-<% } %>
+define(function(require, exports) {<% } %>
     'use strict';
 
     const Mn = require('backbone.marionette');

--- a/generators/webapp/templates/example.controller.js
+++ b/generators/webapp/templates/example.controller.js
@@ -3,8 +3,7 @@
  * @author <%= userName %>
  * @module controllers/example
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports, module) {
-<% } %>
+define(function(require, exports, module) {<% } %>
     'use strict';
 
     const Mn = require('backbone.marionette');

--- a/generators/webapp/templates/example.model.js
+++ b/generators/webapp/templates/example.model.js
@@ -4,8 +4,7 @@
  * @module models/example
  * @requires app
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports) {
-<% } %>
+define(function(require, exports) {<% } %>
     'use strict';
 
     const Backbone = require('backbone');

--- a/generators/webapp/templates/example.view.js
+++ b/generators/webapp/templates/example.view.js
@@ -4,8 +4,7 @@
  * @module views/example
  * @requires models/example
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports, module) {
-<% } %>
+define(function(require, exports, module) {<% } %>
     'use strict';
 
     const Mn      = require('backbone.marionette');

--- a/generators/webapp/templates/helpers/handlebars.helpers.js
+++ b/generators/webapp/templates/helpers/handlebars.helpers.js
@@ -2,8 +2,7 @@
  * @file Helpers that augment Handlebars
  * @author Jason Wohlgemuth
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     var Handlebars = require('handlebars');

--- a/generators/webapp/templates/helpers/jquery.extensions.js
+++ b/generators/webapp/templates/helpers/jquery.extensions.js
@@ -2,8 +2,7 @@
  * @file Methods that extend jQuery
  * @author Jason Wohlgemuth
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     var $ = require('jquery');

--- a/generators/webapp/templates/plugins/radio.logging.js
+++ b/generators/webapp/templates/plugins/radio.logging.js
@@ -40,8 +40,7 @@
  * // Note: Return current logging level with app.radio.level()
  * // Note: Return channels with app.radio.channels()
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports) {
-<% } %>
+define(function(require, exports) {<% } %>
     'use strict';
 
     const _     = require('lodash');

--- a/generators/webapp/templates/plugins/redux.state.js
+++ b/generators/webapp/templates/plugins/redux.state.js
@@ -17,8 +17,7 @@
  * app.dispatch('INCREMENT');
  * app.getState('count');// 43
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports, module) {
-<% } %>
+define(function(require, exports, module) {<% } %>
     'use strict';
 
     const {get, update} = require('lodash');

--- a/generators/webapp/templates/shims/mn.handlebars.templates.shim.js
+++ b/generators/webapp/templates/shims/mn.handlebars.templates.shim.js
@@ -2,8 +2,7 @@
  * This shim replaces lodash template functions with Handlebars.js
  * (not needed if templates are pre-compiled)
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     var Marionette = require('backbone.marionette');

--- a/generators/webapp/templates/shims/mn.morphdom.renderer.shim.js
+++ b/generators/webapp/templates/shims/mn.morphdom.renderer.shim.js
@@ -3,8 +3,7 @@
  * Other options include: inferno, snabbdom, rivets, idom and virtual-dom
  * @see https://github.com/blikblum/marionette.renderers
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     const Mn       = require('backbone.marionette');

--- a/src/project/index.js
+++ b/src/project/index.js
@@ -11,10 +11,9 @@ const {project} = require('../app/prompts');
 const tasks     = require('../app/gruntTaskConfigs');
 const {
     copyTpl,
+    maybeInclude: iff,
     json: {extend}
 } = require('../app/utils');
-
-const iff = (condition, data, defaultValue = []) => (condition ? data : defaultValue);
 
 const COMMAND_LINE_OPTIONS = {
     defaults: {

--- a/src/webapp/index.js
+++ b/src/webapp/index.js
@@ -10,8 +10,8 @@ const tasks     = require('../app/gruntTaskConfigs');
 const {
     copy,
     copyTpl,
-    maybeInclude,
     parseModuleData,
+    maybeInclude: iff,
     json: {extend}
 } = require('../app/utils');
 
@@ -164,16 +164,16 @@ module.exports = class extends Generator {
             ['config/stylelint.config.js', 'config/stylelint.config.js'],
             ['tasks/webapp.js', 'tasks/webapp.js']
         ].concat(// optional dependencies
-            maybeInclude(useAmd, [['_config.js', `${appDirectory}config.js`]])
+            iff(useAmd, [['_config.js', `${appDirectory}config.js`]])
         ).concat(// conditional dependencies
-            maybeInclude(useAmd,
+            iff(useAmd,
                 [
                     ['test/config.js', 'test/config.js'],
                     ['config/_karma.conf.amd.js', 'config/karma.conf.js']
                 ]
             )
         ).concat(
-            maybeInclude(!(useAmd || useJest || useWebpack),
+            iff(!(useAmd || useJest || useWebpack),
                 [
                     ['config/_karma.conf.cjs.js', 'config/karma.conf.js']
                 ]
@@ -183,8 +183,8 @@ module.exports = class extends Generator {
         // Write boilerplate files
         //
         [].concat(
-            maybeInclude(useHandlebars, [['helpers/handlebars.helpers.js', 'helpers/handlebars.helpers.js']]),
-            maybeInclude(useAmd, [['example.webworker.js', 'controllers/example.webworker.js']]),
+            iff(useHandlebars, [['helpers/handlebars.helpers.js', 'helpers/handlebars.helpers.js']]),
+            iff(useAmd, [['example.webworker.js', 'controllers/example.webworker.js']]),
             [[
                 'helpers/jquery.extensions.js',
                 'helpers/jquery.extensions.js'
@@ -235,7 +235,7 @@ module.exports = class extends Generator {
         copy('library/*', `${assetsDirectory}library`, generator);
         copy('omaha.png', `${assetsDirectory}images/logo.png`, generator);
         [].concat(
-            maybeInclude((type === 'none'),
+            iff((type === 'none'),
                 [[// No CSS pre-processor
                     '_style.css',
                     'css/style.css'
@@ -274,8 +274,8 @@ module.exports = class extends Generator {
             'morphdom',
             'redux'
         ].concat(// conditional dependencies
-            maybeInclude(useHandlebars, 'handlebars'),
-            maybeInclude(useAmd, 'requirejs')
+            iff(useHandlebars, 'handlebars'),
+            iff(useAmd, 'requirejs')
         );
         const htmlDevDependencies = [
             'grunt-contrib-htmlmin',
@@ -292,7 +292,7 @@ module.exports = class extends Generator {
             'mdcss',
             'mdcss-theme-github'
         ].concat(
-            maybeInclude(type === 'none', ['postcss-import', 'postcss-cssnext'])
+            iff(type === 'none', ['postcss-import', 'postcss-cssnext'])
         );
         const requirejsDevDependencies = [
             'grunt-contrib-requirejs',
@@ -306,7 +306,7 @@ module.exports = class extends Generator {
             'deamdify',
             'grunt-browserify'
         ].concat(
-            maybeInclude(useBrowserify && !useJest, ['karma-browserify', 'browserify-istanbul'])
+            iff(useBrowserify && !useJest, ['karma-browserify', 'browserify-istanbul'])
         );
         const gruntDependencies = [
             'grunt',
@@ -327,7 +327,7 @@ module.exports = class extends Generator {
             'load-grunt-tasks',
             'time-grunt'
         ].concat(
-            maybeInclude(!useJest, 'grunt-karma')
+            iff(!useJest, 'grunt-karma')
         );
         const workflowDependencies = [
             'babel-cli',
@@ -338,19 +338,19 @@ module.exports = class extends Generator {
             'globby',
             'json-server'
         ].concat(// conditional dependencies
-            maybeInclude(!useBrowserify, 'babel-preset-minify'),
-            maybeInclude(!useJest, requirejsDevDependencies),
+            iff(!useBrowserify, 'babel-preset-minify'),
+            iff(!useJest, requirejsDevDependencies),
             ...gruntDependencies,
             ...htmlDevDependencies,
             ...cssDevDependencies
         );
         const devDependencies = workflowDependencies.concat(
-            maybeInclude(useBrowserify, browserifyDependencies),
-            maybeInclude(useAria, ['grunt-a11y', 'grunt-accessibility']),
-            maybeInclude(useImagemin, 'grunt-contrib-imagemin'),
-            maybeInclude(useLess, 'grunt-contrib-less'),
-            maybeInclude(useSass, 'grunt-contrib-sass'),
-            maybeInclude(useHandlebars, 'grunt-contrib-handlebars', 'grunt-contrib-jst')
+            iff(useBrowserify, browserifyDependencies),
+            iff(useAria, ['grunt-a11y', 'grunt-accessibility']),
+            iff(useImagemin, 'grunt-contrib-imagemin'),
+            iff(useLess, 'grunt-contrib-less'),
+            iff(useSass, 'grunt-contrib-sass'),
+            iff(useHandlebars, 'grunt-contrib-handlebars', 'grunt-contrib-jst')
         );
         generator.npmInstall(dependencies, {save: true});
         generator.npmInstall(devDependencies, {saveDev: true});
@@ -457,7 +457,7 @@ function getPackageJsonAttributes() {
     const scripts = getScripts(generator);
     const babel = {
         plugins: [],
-        presets: [['env', {modules: false}]].concat(maybeInclude(!useBrowserify, 'minify'))
+        presets: [['env', {modules: false}]].concat(iff(!useBrowserify, 'minify'))
     };
     const stylelint = {extends: './config/stylelint.config.js'};
     return {main, scripts, babel, stylelint};
@@ -534,18 +534,18 @@ function getTasks(generator) {
         'watch'
     ]
         .concat(// Project tasks enabled by user
-            maybeInclude(useBenchmark, 'benchmark'),
-            maybeInclude(useCoveralls, 'coveralls'),
-            maybeInclude(useJsinspect, 'jsinspect')
+            iff(useBenchmark, 'benchmark'),
+            iff(useCoveralls, 'coveralls'),
+            iff(useJsinspect, 'jsinspect')
         )
         .concat(// Webapp tasks enabled by user
-            maybeInclude(useAria, ['a11y', 'accessibility']),
-            maybeInclude(useBrowserify, 'browserify'),
-            maybeInclude(useHandlebars, 'handlebars', 'jst'),
-            maybeInclude(useImagemin, ['imagemin', 'copy']),
-            maybeInclude(useLess, 'less'),
-            maybeInclude(useSass, 'sass'),
-            maybeInclude(useWebpack, 'webpack'),
-            maybeInclude(useWebpack || useBrowserify, 'uglify')
+            iff(useAria, ['a11y', 'accessibility']),
+            iff(useBrowserify, 'browserify'),
+            iff(useHandlebars, 'handlebars', 'jst'),
+            iff(useImagemin, ['imagemin', 'copy']),
+            iff(useLess, 'less'),
+            iff(useSass, 'sass'),
+            iff(useWebpack, 'webpack'),
+            iff(useWebpack || useBrowserify, 'uglify')
         );
 }

--- a/src/webapp/templates/_app.js
+++ b/src/webapp/templates/_app.js
@@ -6,8 +6,7 @@
  * @module app
  * @exports app
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports, module) {
-<% } %>
+define(function(require, exports, module) {<% } %>
     'use strict';
 
     const Mn      = require('backbone.marionette');

--- a/src/webapp/templates/_main.js
+++ b/src/webapp/templates/_main.js
@@ -5,8 +5,7 @@
  * @requires router
  * @requires views/example
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     const Backbone = require('backbone');

--- a/src/webapp/templates/_router.js
+++ b/src/webapp/templates/_router.js
@@ -3,8 +3,7 @@
  * @author <%= userName %>
  * @module router
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports) {
-<% } %>
+define(function(require, exports) {<% } %>
     'use strict';
 
     const Mn = require('backbone.marionette');

--- a/src/webapp/templates/example.controller.js
+++ b/src/webapp/templates/example.controller.js
@@ -3,8 +3,7 @@
  * @author <%= userName %>
  * @module controllers/example
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports, module) {
-<% } %>
+define(function(require, exports, module) {<% } %>
     'use strict';
 
     const Mn = require('backbone.marionette');

--- a/src/webapp/templates/example.model.js
+++ b/src/webapp/templates/example.model.js
@@ -4,8 +4,7 @@
  * @module models/example
  * @requires app
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports) {
-<% } %>
+define(function(require, exports) {<% } %>
     'use strict';
 
     const Backbone = require('backbone');

--- a/src/webapp/templates/example.view.js
+++ b/src/webapp/templates/example.view.js
@@ -4,8 +4,7 @@
  * @module views/example
  * @requires models/example
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports, module) {
-<% } %>
+define(function(require, exports, module) {<% } %>
     'use strict';
 
     const Mn      = require('backbone.marionette');

--- a/src/webapp/templates/helpers/handlebars.helpers.js
+++ b/src/webapp/templates/helpers/handlebars.helpers.js
@@ -2,8 +2,7 @@
  * @file Helpers that augment Handlebars
  * @author Jason Wohlgemuth
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     var Handlebars = require('handlebars');

--- a/src/webapp/templates/helpers/jquery.extensions.js
+++ b/src/webapp/templates/helpers/jquery.extensions.js
@@ -2,8 +2,7 @@
  * @file Methods that extend jQuery
  * @author Jason Wohlgemuth
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     var $ = require('jquery');

--- a/src/webapp/templates/plugins/radio.logging.js
+++ b/src/webapp/templates/plugins/radio.logging.js
@@ -40,8 +40,7 @@
  * // Note: Return current logging level with app.radio.level()
  * // Note: Return channels with app.radio.channels()
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports) {
-<% } %>
+define(function(require, exports) {<% } %>
     'use strict';
 
     const _     = require('lodash');

--- a/src/webapp/templates/plugins/redux.state.js
+++ b/src/webapp/templates/plugins/redux.state.js
@@ -17,8 +17,7 @@
  * app.dispatch('INCREMENT');
  * app.getState('count');// 43
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require, exports, module) {
-<% } %>
+define(function(require, exports, module) {<% } %>
     'use strict';
 
     const {get, update} = require('lodash');

--- a/src/webapp/templates/shims/mn.handlebars.templates.shim.js
+++ b/src/webapp/templates/shims/mn.handlebars.templates.shim.js
@@ -2,8 +2,7 @@
  * This shim replaces lodash template functions with Handlebars.js
  * (not needed if templates are pre-compiled)
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     var Marionette = require('backbone.marionette');

--- a/src/webapp/templates/shims/mn.morphdom.renderer.shim.js
+++ b/src/webapp/templates/shims/mn.morphdom.renderer.shim.js
@@ -3,8 +3,7 @@
  * Other options include: inferno, snabbdom, rivets, idom and virtual-dom
  * @see https://github.com/blikblum/marionette.renderers
 **/<% if (moduleFormat === 'amd') { %>
-define(function(require) {
-<% } %>
+define(function(require) {<% } %>
     'use strict';
 
     const Mn       = require('backbone.marionette');

--- a/test/__snapshots__/utils.test.js.snap
+++ b/test/__snapshots__/utils.test.js.snap
@@ -12,3 +12,12 @@ Object {
   "foo": "bar",
 }
 `;
+
+exports[`Utilities Module can optionally return values 1`] = `
+Array [
+  "foo",
+  "b",
+  "c",
+  "d",
+]
+`;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,6 +5,7 @@ const {join}       = require('path');
 const {unlinkSync} = require('fs');
 const {
     json,
+    maybeInclude,
     parseModuleData
 } = require('../generators/app/utils');
 
@@ -23,6 +24,14 @@ describe('Utilities Module', function() {
             'browserify',
             'webpack'
         ]);
+    });
+    it('can optionally return values', () => {
+        const result = [].concat(
+            maybeInclude(true, 'foo', 'bar'),
+            maybeInclude(false, 'a', 'b'),
+            maybeInclude(true, ['c', 'd'])
+        );
+        expect(result).toMatchSnapshot();
     });
 });
 describe('Generator JSON utility', () => {


### PR DESCRIPTION
- Remove extra carriage return before `'use strict';` directives
- Consolidate usage of `maybeInclude` and `iff` (also create unit test for `maybeInclude`)